### PR TITLE
Fixed PubSubMessage having to contain UTF-8 String as payload

### DIFF
--- a/Sources/SwiftyRedis/PubSub.swift
+++ b/Sources/SwiftyRedis/PubSub.swift
@@ -170,7 +170,6 @@ public struct PubSubMessage: FromRedisValue {
                 let pattern = try String(array.popLast())
                 channel = try String(array.popLast())
                 
-                let actual_payload_data: Data
                 if case .BulkString(let data) = array.popLast() {
                     type = .message(pattern: pattern, payload: data)
                 } else {

--- a/Tests/SwiftyRedisTests/PubSubConnectionTests.swift
+++ b/Tests/SwiftyRedisTests/PubSubConnectionTests.swift
@@ -34,7 +34,7 @@ final class PubSubConnectionTests: XCTestCase {
             switch result {
             case let .success(message):
                 XCTAssertEqual(message.channel, "channel1")
-                XCTAssertEqual(message.type, .message(pattern: nil, payload: "Hello, World!"))
+                XCTAssertEqual(message.type, .message(pattern: nil, payload: Data("Hello, World!".utf8)))
             case let .failure(error):
                 XCTFail("Received error: \(error)")
             }
@@ -59,6 +59,6 @@ final class PubSubConnectionTests: XCTestCase {
 
         // Verify the parsed PubSubMessage properties
         XCTAssertEqual(pubSubMessage.channel, "channel1")
-        XCTAssertEqual(pubSubMessage.type, .message(pattern: nil, payload: "Hello, World!"))
+        XCTAssertEqual(pubSubMessage.type, .message(pattern: nil, payload: Data("Hello, World!".utf8)))
     }
 }


### PR DESCRIPTION
Like https://github.com/michaelvanstraten/swifty-redis/issues/9 , current implementation of PubSubMessage can only support UTF8 String. 

This PR enables PubSubMessage to support binary data.

Additionally, the `pattern` and `channel` fields in `PubSubMessage` might also contain binary data. However, in most usage scenarios, this is unlikely to be the case, which is why I haven't modified them alongside the payload. Nonetheless, there's still a possibility that binary data might be used in these fields, and we might need to consider our implementation approach regarding this?


Also, I adjusted a line of code that seemed incorrect: pattern should not be the same as channel.
https://github.com/michaelvanstraten/swifty-redis/blob/f4cdb34bbcb1109801cec54bcb439fcf627f6de6/Sources/SwiftyRedis/PubSub.swift#L168
